### PR TITLE
Fixing a loadingMsg oddity I ran into

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -123,21 +123,24 @@
         // we dont want to fire the ajax multiple times
         props.isDuringAjax = true; 
         
-        // show the loading message and hide the previous/next links
-        props.loadingMsg.appendTo( opts.loadMsgSelector ).show();
-        $( opts.navSelector ).hide(); 
-        
-        // increment the URL bit. e.g. /page/3/
-        props.currPage++;
-        
-        debug('heading into ajax',path);
-        
-        // if we're dealing with a table we can't use DIVs
-        box = $(opts.contentSelector).is('table') ? $('<tbody/>') : $('<div/>');  
-        frag = document.createDocumentFragment();
+        // show the loading message quickly
+        // then hide the previous/next links after we're
+        // sure the loading message was visible
+        props.loadingMsg.appendTo( opts.loadMsgSelector ).show(opts.loadingMsgRevealSpeed, function(){
+          $( opts.navSelector ).hide(); 
 
+          // increment the URL bit. e.g. /page/3/
+          props.currPage++;
 
-        box.load( path.join( props.currPage ) + ' ' + opts.itemSelector,null,loadCallback); 
+          debug('heading into ajax',path);
+
+          // if we're dealing with a table we can't use DIVs
+          box = $(opts.contentSelector).is('table') ? $('<tbody/>') : $('<div/>');  
+          frag = document.createDocumentFragment();
+
+          box.load( path.join( props.currPage ) + ' ' + opts.itemSelector,null,loadCallback);
+        });
+        
         
     }
     
@@ -271,6 +274,7 @@
                           navSelector     : "div.navigation",
                           contentSelector : null,           // not really a selector. :) it's whatever the method was called on..
                           loadMsgSelector : null,
+                          loadingMsgRevealSpeed : 'fast', // controls how fast you want the loading message to come in, ex: 'fast', 'slow', 200 (milliseconds)
                           extraScrollPx   : 150,
                           itemSelector    : "div.post",
                           animate         : false,

--- a/test/test-loadingmsg.html
+++ b/test/test-loadingmsg.html
@@ -89,8 +89,10 @@ Hong Kong Phooey, number one super guy. Hong Kong Phooey, quicker than the human
                      // selector for the NEXT link (to page 2)
       itemSelector : "#body p",
                      // selector for all items you'll retrieve
-      loadMsgSelector : "#footer"
+      loadMsgSelector : "#footer",
                      // selector for the loading message
+       loadingMsgRevealSpeed : "fast"
+                      // speed at which the loadingText should appear
     }, function(){ 
       window.callbackcontext = this;
       window.console && console.log('callbackcontext',this,$(this).find('p'))


### PR DESCRIPTION
I ran into an issue where the loadingMsg was not consistently showing up and it seemed to be due to .show() basically not working fast enough. If the .load() pulled in the data from the server fast enough, the loadingMsg wouldn't get a chance to be fully revealed. 

The reason I decided to change the current behavior is this made the loadingMsg inconsistent. I figured that since it gets set, it should have a chance to be shown before the script moves on. So I moved what happens after the .show() to .show()'s callback to ensure it doesn't happen until .show() is done. 
