### PR TITLE
Small Core Fixes

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -439,8 +439,8 @@
 	                    case 'html+callback':
 
 	                        instance._debug('Using HTML via .load() method');
-	                        box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(jqXHR, textStatus) {
-	                            instance._loadcallback(box, jqXHR.responseText);
+	                        box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(responseText) {
+	                            instance._loadcallback(box, responseText);
 	                        });
 
 	                        break;
@@ -498,7 +498,7 @@
 		// Unbind from scroll
 		unbind: function infscr_unbind() {
 			this._binding('unbind');
-		},
+		}
 
     }
 


### PR DESCRIPTION
Hi again,

Here are some proposed changes to the core.
- Removed an extra comma that may cause problems in some versions of IE.
- The 'html+callback' case in infscr_retrieve uses jQuery's [.load()](http://api.jquery.com/load/) function, which already returns the raw responseText - as opposed to [.ajax()](http://api.jquery.com/jQuery.ajax/) which does return the XMLHttpRequest object.

Gabriel.
