### PR TITLE
Behaviors Proposal

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -23,7 +23,7 @@
 	$.infinitescroll.defaults = {
 		callback: function () { },
 		debug: false,
-		behavior: undefined,
+		behavior: 'default',
 		binder: $(window), // used to cache the selector
 		nextSelector: "div.navigation a:first",
 		loadMsgSelector: null,
@@ -228,6 +228,15 @@
         _loadcallback: function infscr_loadcallback(box, data) {
 
             var opts = this.options,
+                loadCallback = '_loadcallback_' + opts.behavior;
+            
+            this[loadCallback](box, data);
+            
+        },
+
+        // Default Load Callback
+        _loadcallback_default: function infscr_loadcallback_default (box, data) {
+            var opts = this.options,
 	    		callback = this.options.callback, // GLOBAL OBJECT FOR CALLBACK
 	    		result = (opts.isDone) ? 'done' : (!opts.appendCallback) ? 'no-append' : 'append',
 	    		frag;
@@ -340,14 +349,24 @@
         },
 
 		// Behavior is determined
-		// If the behavior option is undefined, it will set to default and bind to scroll
+		// The default behavor is 'default'
 		_setup: function infscr_setup() {
 			
 			var opts = this.options;
-			(!opts.behavior)? this._binding('bind') : this['_setup_'+opts.behavior]();
+                        this._debug('Using behavior', opts.behavior);
+			
+                        this['_setup_'+opts.behavior]();
 			
 			return false;
+		},
 			
+                // Default Behavior (will be used to setup unless a behavior is explicitely specified
+                // Simply binds to scroll
+                _setup_default: function infscr_setup_default() {
+                        var opts = this.options;
+			this._binding('bind');
+			
+			return false;
 		},
 
         // Show done message


### PR DESCRIPTION
Hello guys,

I tried creating a behavior for Magento but couldn't find a way to hook into the _loadcallback function. Looks like behaviors were missing that ability. If I'm wrong and just missed something, please ignore this pull request.

What I did is leverage behaviors for the _loadcallback function. I also refactored the overall behavior mechanism a bit:
- Changed the default `behavior` option from undefined to 'default'.
- Changed the `_setup` and `_loadcallback` functions to _always_ leverage behaviors.
- Moved the original code for `_setup` and `_loadcallback` to `_setup_default` and `_loadcallback_default`, respectively.
- In other words, I implemented a 'default' behavior within the core.

I successfully tested and used this new system for the [Magento-Infinitescroll](https://github.com/gabrielsomoza/Magento-InfiniteScroll) module.

Gabriel.
