### PR TITLE
check for this.options in ._debug()

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -167,7 +167,7 @@
         // Console log wrapper
         _debug: function infscr_debug() {
 
-			if (this.options.debug) {
+			if (this.options && this.options.debug) {
                 return window.console && console.log.call(console, arguments);
             }
 


### PR DESCRIPTION
I found a bug where `_validate()` calls `_debug()` before `this.options` is set in `_create()`. Checking for `this.options` in `_debug()` should resolve this.
