### PR TITLE
Add a local mode

### DIFF
--- a/behaviors/local.js
+++ b/behaviors/local.js
@@ -1,0 +1,26 @@
+// Calculate internal height (used for local scroll)
+// this function is from the old localMode I think?
+function infsrc_local_hiddenHeight(element) {
+   var height = 0;
+   $(element).children().each(function() {
+     height = height + $(this).outerHeight(false);
+   });
+   return height;
+}
+
+$.extend($.infinitescroll.prototype,{
+   _nearbottom_local: function infscr_nearbottom_local() {
+       var opts = this.options, instance = this,
+           pixelsFromWindowBottomToBottom = infsrc_local_hiddenHeight(opts.binder)
+               - $(opts.binder).scrollTop() - $(opts.binder).height();
+
+       if (opts.local_pixelsFromNavToBottom == undefined){
+           opts.local_pixelsFromNavToBottom = infsrc_local_hiddenHeight(opts.binder) +
+		 $(opts.binder).offset().top - $(opts.navSelector).offset().top;
+       }
+       instance._debug('local math:', pixelsFromWindowBottomToBottom,
+opts.local_pixelsFromNavToBottom);
+
+       return (pixelsFromWindowBottomToBottom - opts.bufferPx < opts.local_pixelsFromNavToBottom);
+   }
+});

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -337,8 +337,7 @@
 
             // if behavior is defined and this function is extended, call that instead of default
 			if (!!opts.behavior && this['_nearbottom_'+opts.behavior] !== undefined) {
-				this['_nearbottom_'+opts.behavior].call(this);
-				return;
+				return this['_nearbottom_'+opts.behavior].call(this);
 			}
 
 			this._debug('math:', pixelsFromWindowBottomToBottom, opts.pixelsFromNavToBottom);


### PR DESCRIPTION
Force the nearbottom behavior to return the plugin's return value, and then use that to implement a local mode like the docs say should exist.

Use this by including behaviors/local.js in your script and then specify behavior:'local' in your options.

Additionally, you need to specify what the container is that will be scrolling (this defaults to the window).  I used options.binder for this, i.e. binder:'#myscrollingdiv'

I'm sure something like this is in the works, as I just ripped code from other githubs to make it... but if it happens to be what you were going to do anyways, wonderful!  It also fixes the bug I reported paulirish/infinite-scroll#105
