### PR TITLE
Since drupal uses 0,1,2...n-1 page notation, we must adjust currPage arg...

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -212,6 +212,7 @@
                 // thx Jerod Fritz, vladikoff
                 if (path.match(/^(.*?page=)1(\/.*|$)/)) {
                     path = path.match(/^(.*?page=)1(\/.*|$)/).slice(1);
+		    this.options.state.currPage-=1; // if second page =1 we should adjust currPage parameter
                     return path;
                 } else {
                     this._debug('Sorry, we couldn\'t parse your Next (Previous Posts) URL. Verify your the css selector points to the correct A tag. If you still get this error: yell, scream, and kindly ask for help at infinite-scroll.com.');


### PR DESCRIPTION
Title says it all. Current code always omitted page=1.

It loaded:
page=0 (start)
page=2,
page=3
page=n (not exists)

With this fix, it loads:
page=0
page=1,
page=2.
.
.
.
page=n-1
