### PR TITLE
Allows themes to modify which pages will load infinite scroll

### DIFF
--- a/wordpress-plugin/wp_infinite_scroll.php
+++ b/wordpress-plugin/wp_infinite_scroll.php
@@ -195,6 +195,9 @@ function wp_inf_scroll_init()
 		$error_reason = 'No Posts to Display';
 		$load_infinite_scroll = false;		
 		}
+	
+	/* Hook for plugins and themes to modify where and when infinite scroll will run */
+	$load_infinite_scroll = apply_filters('load_infinite_scroll', $load_infinite_scroll);
 		
 	/* Pre-flight checks complete. Are we good to fly? */	
 	if($load_infinite_scroll)


### PR DESCRIPTION
I added a simple WordPress hook so themes can easily customize where to run the infinite scroll script. 
For example, on a site I run there is a page that loads posts that I want to run infinite scroll on, but where by default the plugin does not load. To load the script using this commit I can add this to my theme's functions.php:

```
function my_load_infinite_scroll( $load_infinite_scroll ) {
    if( is_page('news') )
        return true;
    return $load_infinite_scroll;
}
add_filter('load_infinite_scroll', 'my_load_infinite_scroll');
```
