### PR TITLE
Call the callback before loading.finished, as in many cases the callback prepares the data in ways that would benefit from the continuation of the loading indicator

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -314,6 +314,9 @@
 
             }
 
+            // allow the user to prepare the loaded data
+            callback(this,data);
+
             // loadingEnd function
 			opts.loading.finished.call($(opts.contentSelector)[0],opts)
 
@@ -326,9 +329,6 @@
             } else {
                 opts.state.isDuringAjax = false; // once the call is done, we can allow it again.
             }
-
-            callback(this,data);
-
         },
 
         _nearbottom: function infscr_nearbottom() {


### PR DESCRIPTION
If the users prefer the other behavior, they can call loading.finished themselves from within their callback.

Originally ran into this problem with jquery.masonry with jquery.infinite-scroll - there was a significant gap between the loading indicator being removed and the new results being displayed. 
