### PR TITLE
use href of nextSelector from responseText for next AJAX call

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -292,7 +292,12 @@
                     if (children.length == 0) {
                         return this._error('end');
                     }
-
+					
+					// added by esmizzle 2012-01-26 - update the path to the link for the next set of elements
+					var nexturl = $(data).find(opts.nextSelector).attr('href');
+                    this._debug('nexturl: '+ nexturl)
+					this.options.path[0] = nexturl;
+					this.options.path[1] = '#pathcomplete';
 
                     // use a documentFragment because it works when content is going into a table or UL
                     frag = document.createDocumentFragment();
@@ -487,7 +492,8 @@
 	                // if we're dealing with a table we can't use DIVs
 	                box = $(opts.contentSelector).is('table') ? $('<tbody/>') : $('<div/>');
 
-	                desturl = path.join(opts.state.currPage);
+					desturl = (path[1] == '#pathcomplete') ? path[0] : path.join(opts.state.currPage); // only throw the currPage in there if we need it
+	                instance._debug('desturl: '+desturl);
 
 	                method = (opts.dataType == 'html' || opts.dataType == 'json') ? opts.dataType : 'html+callback';
 	                if (opts.appendCallback && opts.dataType == 'html') method += '+callback'
@@ -495,11 +501,10 @@
 	                switch (method) {
 
 	                    case 'html+callback':
-
 	                        instance._debug('Using HTML via .load() method');
-	                        box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(responseText) {
-	                            instance._loadcallback(box, responseText);
-	                        });
+							box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(responseText) {
+								instance._loadcallback(box, responseText);
+							});
 
 	                        break;
 


### PR DESCRIPTION
I was struggling implementing this plugin because I needed two query string variables to update my pagination results.  incrementing currPage didn't help me.

I wrote the logic server side so that my 'nextSelector' link href would always have the correct custom pagination results.  that is, i made sure the 'nextSelector' link on the _next_ page had the correct info.

since we download all the data that we retrieve from the ajax call into 'data' in the infscr_loadcallback function, i set this.options.path[0] to the href I grabbed from opts.nextSelector.  at this point I didn't really need the currPage or this.options.path[1] - unless there's another reason I can't think of.

interested in your thoughts on this.  thanks for the great plugin!
