### PR TITLE
Do not attach object via jQuery.data() when object instantiation fails

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -17,9 +17,9 @@
 		
 		this.element = $(element);
 		
-		// Don't instantiate the object in the event of a failed creation
+                // Flag the object in the event of a failed creation
 		if (!this._create(options, callback)) {
-                  return false;
+                  this.failed = true;
                 }
 	
 	};
@@ -657,7 +657,12 @@
                     } else {
 
                         // initialize new instance
-                        $.data(this, 'infinitescroll', new $.infinitescroll(options, callback, this));
+                        instance = new $.infinitescroll(options, callback, this);
+
+                        // don't attach if instantiation failed
+                        if (!instance.failed) {
+                          $.data(this, 'infinitescroll', instance);
+                        }
 
                     }
 


### PR DESCRIPTION
If the options don't pass validation or if the path is missing, then the infinitescroll object is not instantiated.  In this case, we must detect the failure and prevent the defunct object from being attached to the dom element via jQuery.data()
