### PR TITLE
Remove phpdoc author information from WordPress plugin includes headers

### DIFF
--- a/wordpress-plugin/includes/admin.php
+++ b/wordpress-plugin/includes/admin.php
@@ -2,7 +2,6 @@
 /**
  * Infinite Scroll Administrative Backend
  * @subpackage Admin
- * @author Benjamin J. Balter <ben@balter.com>
  * @package Infinite_Scroll
  */
 

--- a/wordpress-plugin/includes/options.php
+++ b/wordpress-plugin/includes/options.php
@@ -2,7 +2,6 @@
 /**
  * Provides interface to store and retrieve plugin and user options
  * @subpackage Infinite_Scroll_Options
- * @author Benjamin J. Balter
  * @package Infinite_Scroll
  */
 class Infinite_Scroll_Options {

--- a/wordpress-plugin/includes/presets.php
+++ b/wordpress-plugin/includes/presets.php
@@ -18,7 +18,6 @@
  * Hierarchy of presets: 1) User specified, 2) (admin specified) custom preset, 3) community specified preset
  *
  * @subpackage Presets
- * @author Benjamin J. Balter <ben@balter.com>
  * @package Infinite_Scroll
  */
 

--- a/wordpress-plugin/includes/submit.php
+++ b/wordpress-plugin/includes/submit.php
@@ -2,7 +2,6 @@
 /**
  * Prompts users to submit CSS Selectors to WP Forums when appropriate
  * @subpackage Infinite_Scroll_Submit
- * @author Benjamin J. Balter
  * @package Infinite_Scroll
  */
 class Infinite_Scroll_Submit {


### PR DESCRIPTION
Each of the files in `wordpress-plugin/includes/` has an `@author` PHPDoc parameter due to my PHPTidy script. Simply removed the `@author` line completely from all includes files, with apologies.
