### PR TITLE
Fix for typo on refresh_cache action hook in presets.php of WordPress plugin

### DIFF
--- a/wordpress-plugin/includes/presets.php
+++ b/wordpress-plugin/includes/presets.php
@@ -45,7 +45,7 @@ class Infinite_Scroll_Presets {
 		add_action( 'wp_ajax_infinite-scroll-delete-preset', array( &$this, 'process_ajax_delete' ) );
 		add_filter( $this->parent->prefix . 'presets', array( &$this, 'merge_custom_presets' ) );
 		add_filter( $this->parent->prefix . 'options', array( &$this, 'default_to_presets'), 9 );
-		add_action( $this->parent->prefix . 'refesh_cache', array( &$this, 'get_presets' ) );
+		add_action( $this->parent->prefix . 'refresh_cache', array( &$this, 'get_presets' ) );
 
 	}
 


### PR DESCRIPTION
Typo in action hook that fires to asynchronously grab presets would prevent cache from refreshing on cron.

( typo on [line 48](https://github.com/benbalter/infinite-scroll-wordpress-plugin/blob/master/wordpress-plugin/includes/presets.php#L48) of presets.php )
