### PR TITLE
Reduce preset ttl to 86000 to ensure daily cron *always* refreshes the cache

### DIFF
--- a/wordpress-plugin/includes/presets.php
+++ b/wordpress-plugin/includes/presets.php
@@ -28,7 +28,7 @@ class Infinite_Scroll_Presets {
 //	public $preset_url        = 'http://plugins.svn.wordpress.org/infinite-scroll/branches/PresetDB/presets.csv';
 	public $preset_url		  = 'https://raw.github.com/benbalter/Infinite-Scroll/presetDB/presets.csv';
 	public $custom_preset_key = 'infinite_scroll_presets';
-	public $ttl               = 86400; //TTL of transient cache in seconds, 1 day = 86400 = 60*60*24
+	public $ttl               = 86000; //TTL of transient cache in seconds, 1 day = 86400 = 60*60*24
 	public $keys              = array( 'theme', 'contentSelector', 'navSelector', 'itemSelector', 'nextSelector' );
 
 	/**


### PR DESCRIPTION
The preset TTL was set to _exactly_ one day. Assuming the WordPress daily cron fires _exactly_ every 86000 seconds, because there's going to be a lag as the server makes the HTTP request, the cache won't actually be set until a few seconds (or at least one) after that, thus 86000 later (when cron fires again), the cache will (in theory) still be valid (until say 86001 seconds from when the previous cron fired).

Reduced TTL to 86000 (arbitrary, but approx. 6 minutes less than a full day) to ensure cache is always invalid when cron fires.

May make sense to look into using [TLC Transients](https://github.com/markjaquith/WP-TLC-Transients) as a wrapper for WordPress's native transient functionality to ensure that even if Cron doesn't fire for whatever reason, user isn't delayed as presets are fetched on option screen (old presets would be served while new is fetched in background).
