### PR TITLE
Update presets.php to use wp_get_themes since get_themes is deprecated starting in 3.4

### DIFF
--- a/wordpress-plugin/includes/submit.php
+++ b/wordpress-plugin/includes/submit.php
@@ -31,7 +31,7 @@ class Infinite_Scroll_Submit {
 			return;
 				
 		//their current theme's preset selectors, false if none found (good)
-		$preset = $this->parent->presets->get_preset( get_current_theme() );
+		$preset = $this->parent->presets->get_preset( get_stylesheet() );
 
 		//their network-wide custom presets, false if none found (bad)
 		$custom = $this->parent->presets->get_custom_presets( );

--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -74,8 +74,8 @@ class Infinite_Scroll {
 		add_action( 'wp_footer', array( &$this, 'footer' ), 100 ); //low priority will load after i18n and script loads
 
 		//preset cron
-		register_activation_hook( __FILE__, $this->presets->schedule );
-		register_deactivation_hook( __FILE__, $this->presets->unschedule );
+		register_activation_hook( __FILE__, array( &$this->presets, 'schedule' ) );
+		register_deactivation_hook( __FILE__, array( &$this->presets, 'unschedule' ) );
 
 		//404 fix
 		add_action( 'wp', array( &$this, 'paged_404_fix' ) );


### PR DESCRIPTION
Note: in 3.4, the way WordPress organizes themes changed significantly. Themes are now keyed by theme slug (stylesheet) rather than by theme name (title).

As a result, there's a bit of duplication / normalizing of theme data to ensure back compatability pre 3.4.

Internally, presets.php always expects, and always returns data keyed to theme slug, and translates it internally for pre-3.4 functions as needed.

This fixes #169.
