### PR TITLE
Fixed bug in validation to confirm that all selectors return results

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -443,6 +443,7 @@
                     this._debug('Your ' + key + ' found no elements.');
                     return false;
                 }
+                return true;
             }
             
             return true;


### PR DESCRIPTION
An earlier change was causing the plugin to stop working and there is absolutely no output being returned in the console. It was working fine prior to this version: https://github.com/paulirish/infinite-scroll/commit/8ba7875dec22e76d70a70f2f0ef55fa068404d69

Rolling back this change causes the plugin to work again. It also seems to be related to issue #181 where the author has reported the same problem. I'm not sure about the very technical details of this issue, but I've successfully identified the point at which it was caused.
