### PR TITLE
Add Ajax method to options

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -60,7 +60,8 @@
         errorCallback: function () { },
         infid: 0, //Instance ID
         pixelsFromNavToBottom: undefined,
-        path: undefined
+        path: undefined,
+        ajaxType: 'post'
     };
 
 
@@ -507,8 +508,13 @@
                         case 'html+callback':
 
                             instance._debug('Using HTML via .load() method');
-                        box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(responseText) {
+                        $.ajax({
+                          url: desturl,
+                          type: opts.ajaxType,
+                          success: function(responseText) {
+                            box.html($(responseText).find(opts.itemSelector));
                             instance._loadcallback(box, responseText);
+                          }
                         });
 
                         break;


### PR DESCRIPTION
The current version uses jquery's `load()` method to make requests, `load()` can only invoke a POST request.
but sometimes We need to make a GET request. For example, I am a rails developer, and GET and POST to the same url will do totally different things.

I recommend to add the `ajaxType` option.
