### PR TITLE
style wrapping div that becomes visible during loading

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -510,9 +510,6 @@
                         case 'html+callback':
 
                             instance._debug('Using HTML via .load() method');
-                            console.log(opts.itemSelector);
-                            console.log(box);
-
                         box.load(desturl + ' ' + opts.itemSelector, null, function infscr_ajax_callback(responseText) {
                             instance._loadcallback(box, responseText);
                         });


### PR DESCRIPTION
Hi Paul,

Thanks for your nice work. I came on this problem with appended elements to a table. The div was causing the elements on the page to "squeeze" over when it was displayed during the loading phase. So, I added a style option to the wrapping to. This fixes "squeeze" effect when div causes reflow of elements.

I am not sure this is the best solution, but it allowed me to fix the weird compressing visual effect when the div became visible in the element flow.

If there is a better way to do this with the existing code... I am all ears!

Thanks,
Daniel
