### PR TITLE
Added pathParseOnce option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ $('.selector').infinitescroll({
   extraScrollPx: 150,
   itemSelector: "div.post",
   animate: false,
+  pathParseOnce: false, // If true, pathParse will be called again before loading items 
   pathParse: undefined,
   dataType: 'html',
   appendCallback: true,

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -57,6 +57,7 @@
         itemSelector: "div.post",
         animate: false,
         pathParse: undefined,
+        pathParseOnce: true, 
         dataType: 'html',
         appendCallback: true,
         bufferPx: 40,
@@ -504,7 +505,7 @@
 
             var instance = this,
             opts = instance.options,
-            path = opts.path,
+            path = opts.pathParseOnce ? opts.path : this._determinepath($(opts.nextSelector).attr('href')), 
             box, frag, desturl, method, condition,
             pageNum = pageNum || null,
             getPage = (!!pageNum) ? pageNum : opts.state.currPage;


### PR DESCRIPTION
Added pathParseOnce option : when set to true, allows to call _determinePath() each time retrieve() is called.

Useful to be able to modify another parameter than the page number in the URL that will be used to load next items.

Also modified Readme.

On my webapp I needed to change another parameter, and pathParse was called once. 
I think this can be useful for somebody else. 
