### PR TITLE
Wordpress Plugin Defaults manager fatal error fix (WP 3.4+)

### DIFF
--- a/wordpress-plugin/includes/presets.php
+++ b/wordpress-plugin/includes/presets.php
@@ -527,7 +527,7 @@ class Infinite_Scroll_Presets {
 	
 		//3.4+
 		if ( function_exists( 'wp_get_theme' ) )
-			return ( wp_get_theme( $theme ) ) ? true : false;
+			return ( wp_get_theme( $theme->theme )->exists() ) ? true : false;
 	
 		//pre 3.4
 		$themes = get_themes();


### PR DESCRIPTION
The plugin compares the presets list against installed Wordpress themes. Previously it was passing an object to the wp_get_theme() function which only accepts strings. Changed to pass the theme name (string) and call the exists function.
