### PR TITLE
Wordpress plugin upgrade fixes for debug/behaviors/img

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -190,8 +190,8 @@ class Infinite_Scroll {
 			'post_selector' => 'itemSelector',
 			'nav_selector' => 'navSelector',
 			'next_selector' => 'nextSelector',
-            'behavior' => 'behavior',
-            'debug' => 'debug'
+			'behavior' => 'behavior',
+			'debug' => 'debug'
 		);
 
 		$old = get_option( 'infscr_options' );
@@ -239,19 +239,19 @@ class Infinite_Scroll {
 			}
 		}
         
-        //if the user is still using the default ajax-loader.gif then update the location
-        if( isset($new['img']) )
-            $new['img'] = str_replace("wp-content/plugins/infinite-scroll/ajax-loader.gif",
-                                      "wp-content/plugins/infinite-scroll/img/ajax-loader.gif",
-                                      $new['img']);
-                                      
-        //regardless of which upgrade, ensure that debug is now set to boolean string rather than int
-        //if it wasn't originally on then just set it to the plugin default
-        if( isset($new['debug']) && $new['debug'] == 1 )
-            $new['debug'] = "true";
-        else
-            unset( $new['debug'] );
-        
+		//if the user is still using the default ajax-loader.gif then update the location
+		if( isset($new['img']) )
+			$new['img'] = str_replace("wp-content/plugins/infinite-scroll/ajax-loader.gif",
+									  "wp-content/plugins/infinite-scroll/img/ajax-loader.gif",
+									  $new['img']);
+
+		//regardless of which upgrade, ensure that debug is now set to boolean string rather than int
+		//if it wasn't originally on then just set it to the plugin default
+		if( isset($new['debug']) && $new['debug'] == 1 )
+			$new['debug'] = "true";
+		else
+			unset( $new['debug'] );
+
 		//don't pass an empty array so the default filter can properly set defaults
 		if ( empty( $new['loading'] ) )
 			unset( $new['loading'] );


### PR DESCRIPTION
Just added the debug and behavior to the list of options to be upgraded to the new Wordpress plugin storage format. Added a search and replace for people still using the old ajax-loader.gif image which has now been moved to the img folder. Found during testing for #251
