### PR TITLE
Fix generated img option in Wordpress plugin

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -93,7 +93,7 @@ class Infinite_Scroll {
 			'loading' => array(
 				'msgText'         => __( '<em>Loading...</em>', 'infinite-scroll' ),
 				'finishedMsg'     => __( '<em>No additional posts.</em>', 'infinite-scroll' ),
-                'img'             => plugins_url( 'img/ajax-loader.gif', __FILE__ )
+				'img'             => plugins_url( 'img/ajax-loader.gif', __FILE__ )
 			),
 			'nextSelector'    => '#nav-below a:first',
 			'navSelector'     => '#nav-below',


### PR DESCRIPTION
Pretty self explanatory, the img property was originally just defined on its own rather than under loading so the plugin was just reverting to the default image. Partially fix for #276
