### PR TITLE
Force debug option to be stored as bool rather than string.

### DIFF
--- a/wordpress-plugin/includes/options.php
+++ b/wordpress-plugin/includes/options.php
@@ -72,6 +72,9 @@ class Infinite_Scroll_Options {
 		//pull existing image if none is given
 		if ( empty( $options["loading"]['img'] ) )
 			$options["loading"]['img']  = $this->loading["img"];
+			
+		//force debug as bool
+		$options['debug'] = (bool) $options['debug'];
 
 		return apply_filters( $this->parent->prefix . 'options_validate', $options );
 

--- a/wordpress-plugin/templates/footer.php
+++ b/wordpress-plugin/templates/footer.php
@@ -5,8 +5,5 @@
  */
 ?>
 <script type="text/javascript">
-// Because the `wp_localize_script` method makes everything a string
-infinite_scroll.debug = "true" === infinite_scroll.debug;
-
 jQuery( infinite_scroll.contentSelector ).infinitescroll( infinite_scroll, function(data) { eval(infinite_scroll.callback); });
 </script>

--- a/wordpress-plugin/templates/options.php
+++ b/wordpress-plugin/templates/options.php
@@ -130,7 +130,7 @@ function isBehavior($value, $behavior) {
 			<?php _e("Debug", "infinite-scroll") ?>
 		</th>
 		<td>
-			<input type="checkbox" id="infinite_scroll[debug]" name="infinite_scroll[debug]" value="true" <?php if ($this->parent->options->debug === "true") { print("checked=\"checked\""); } ?> />
+			<input type="checkbox" id="infinite_scroll[debug]" name="infinite_scroll[debug]" value="true" <?php checked( $this->parent->options->debug ) ?> />
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
This will output (via `wp_localize_script()`) as either "1" or "0" (rather than "true" or "" as did previosly).

When javascript evaluates the truthiness of a string "1" evaluates to true, and "0" (or "") evaluates to false.

This saves the need to manually check for the string "true" on each frontend load.

Additionally, on the options screen, use core's `checked()` API to toggle the checkbox, rather than custom coding a check.
