### PR TITLE
Wordpress: Pass newElements and data parameters in callback function

### DIFF
--- a/wordpress-plugin/templates/footer.php
+++ b/wordpress-plugin/templates/footer.php
@@ -8,5 +8,5 @@
 // Because the `wp_localize_script` method makes everything a string
 infinite_scroll.debug = "true" === infinite_scroll.debug;
 
-jQuery( infinite_scroll.contentSelector ).infinitescroll( infinite_scroll, function(data) { eval(infinite_scroll.callback); });
+jQuery( infinite_scroll.contentSelector ).infinitescroll( infinite_scroll, function(newElements, data) { eval(infinite_scroll.callback); });
 </script>


### PR DESCRIPTION
Pretty self-explanatory, provide both the newElements and data parameters; primarily to retain backwards compatibility with people who used the callback previously. (Currently we're only passing the "data" parameter.)
