### PR TITLE
Upgrade database sequentially

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -178,16 +178,8 @@ class Infinite_Scroll {
 	 * @param int $to version going to
 	 */
 	function upgrade( $from , $to ) {
-		if ($from == 2.5) {
-			$old = get_option("infinite_scroll");
-			$new = $old;
-
-			$new["loading"]["img"] = $old["img"];
-			unset($new["img"]);
-
-			$this->options->set_options($new);
-
-		} else if ($from < 2.5) {
+		
+		if ($from < 2.5) {
 			//array of option conversions in the form of from => to
 			$map = array(
 				'js_calls' => 'callback',
@@ -266,6 +258,20 @@ class Infinite_Scroll {
 			if ( $from < 2.5 )
 				$this->presets->migrate();
 		}
+		
+		//migrate loading image
+		if ($from < 2.6) {
+		
+			$old = get_option("infinite_scroll");
+			$new = $old;
+
+			$new["loading"]["img"] = $old["img"];
+			unset($new["img"]);
+
+			$this->options->set_options($new);
+
+		}		
+			                     
 	}
 
 


### PR DESCRIPTION
Move the 2.6 upgrade bath below the 2.5 upgrade path, and do not make the if statement an else.

This allows a user to upgrade from pre-2.5 to 2.6 (previously if a user was < 2.6, they would not trigger the 2.5 upgrade) and allows upgrades down the line (e.g, 2.7) to simply upgrade from 2.6 (because it can assume the 2.5 upgrade was triggered).
