### PR TITLE
Abstract behaviors.

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -47,7 +47,12 @@ class Infinite_Scroll {
 	public $prefix    = 'infinite_scroll_'; //prefix to append to all options, API calls, etc. w/ trailing underscore
 	public $file      = null;
 	public $version   = '2.6';
-
+	public $behaviors = array(  //array of behaviors as key => array( label => js file ) (without extension)
+	                      'twitter' => array( 'label' => 'Manual Trigger', 'src'  => 'manual-trigger' ),
+	                      'local'   => array( 'label' => 'Local', 'src' => 'local' ),
+	                      'cufon'   => array( 'label' => 'Cufon', 'src' => 'cufon' ),
+	                      'masonry' => array( 'label' => 'Masonry/Isotope', 'src' => 'masonry-isotope')
+	                   );
 	/**
 	 * Construct the primary class and auto-load all child classes
 	 */
@@ -99,7 +104,7 @@ class Infinite_Scroll {
 			'itemSelector'    => '.post',
 			'contentSelector' => '#content',
 			'debug'           => WP_DEBUG,
-			"behavior"		  => ""
+			'behavior'		    => ''
 		);
 	}
 
@@ -121,21 +126,17 @@ class Infinite_Scroll {
 		$options = apply_filters( $this->prefix . 'js_options', $this->options->get_options() );
 		wp_localize_script( $this->slug, $this->slug_, $options );
 
-		// Output a behavior script if needed
-		if ($options["behavior"]) {
-			$scripts["twitter"] = "manual-trigger.js";
-			$scripts["local"] = "local.js";
-			$scripts["cufon"] = "cufon.js";
-			$scripts["masonry"] = "masonry-isotope.js";
+		// If no behavior, we're done, kick
+		if ( !$options['behavior'] )
+		  return;
 
-			$behaviorFile = $scripts[$options["behavior"]];
+		//sanity check
+		if ( !array_key_exists( $options['behavior'], $this->behaviors ) )
+		  return _doing_it_wrong( 'Infinite Scroll behavior', "Behavior {$options['behavior']} not found", $this->version );
+		
+		$src = 'behaviors/' . $this->behaviors[ $options['behavior'] ]['src'] . '.js';
+		wp_enqueue_script( $this->slug . "-behavior", plugins_url( $src, __FILE__ ), array( "jquery", $this->slug ), $this->version, true );
 
-			if ($behaviorFile) {
-				$behaviorFile = "/behaviors/" . $behaviorFile;
-				wp_enqueue_script($this->slug . "-behavior", plugins_url($behaviorFile, __FILE__),
-					array("jquery", $this->slug), $this->version, true);
-			}
-		}
 	}
 
 	/**

--- a/wordpress-plugin/templates/options.php
+++ b/wordpress-plugin/templates/options.php
@@ -104,24 +104,11 @@
 			<?php _e("Behavior", "infinite-scroll") ?>
 		</th>
 		<td>
-
-<?php
-$behavior = $this->parent->options->behavior;
-
-function isBehavior($value, $behavior) {
-	if ($value === $behavior) {
-		print("selected=\"selected\"");
-	}
-}
-
-?>
-
 			<select id="infinite_scroll[behavior]" name="infinite_scroll[behavior]">
-				<option <?php isBehavior("", $behavior); ?> value="">Default</option>
-				<option <?php isBehavior("twitter", $behavior); ?> value="twitter">Manual Trigger</option>
-				<option <?php isBehavior("local", $behavior); ?> value="local">Local</option>
-				<option <?php isBehavior("cufon", $behavior); ?> value="cufon">Cufon</option>
-				<option <?php isBehavior("masonry", $behavior); ?> value="masonry">Masonry/Isotope</option>
+  			<option <?php selected("", $this->parent->options->behavior); ?> value="">Default</option>
+  			<?php foreach ( $this->parent->behaviors as $key => $behavior ) { ?>
+				  <option value="<?php echo $key; ?>" <?php selected( $key, $this->parent->options->behavior ); ?>><?php echo $behavior['label']; ?></option>
+				<?php } ?>
 			</select>
 		</td>
 	</tr>


### PR DESCRIPTION
Previous behavior implementation hard coded behaviors/labels/paths into options page and into `enqueue_js`.

Instead, abstract out the behaviors into a variable within the class, loop on options page, and kick as early as possible on `enqueue` if no behaviors are loaded.

This patch also uses the core `selected()` API on the options screen, and prevents an error for treating an uninitialized variable as an array within `enqueue_js`.

This way, if another behavior is added, it is simply a matter of adding a behavior to the array at the top of the main class.

No changes necessary to the database.
