### PR TITLE
Update the initial _determinepath paging parameter guess to use the last instance of a found 2.

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -259,7 +259,7 @@
                 return opts.pathParse(path, this.options.state.currPage+1);
 
             } else if (path.match(/^(.*?)\b2\b(.*?$)/)) {
-                path = path.match(/^(.*?)\b2\b(.*?$)/).slice(1);
+                path = path.match(/^(.*?)\b2\b(?!.*\b2\b)(.*?$)/).slice(1);
 
                 // if there is any 2 in the url at all.    
             } else if (path.match(/^(.*?)2(.*?$)/)) {


### PR DESCRIPTION
Currently when trying to determine the location of the paging parameter in a path if a pathParse is not specified, a regex is used to find the first instance of a \b anchored 2 in the path. 

This tweak to the regex would tell it to splice on the last found \b anchored 2, as paging parameters are usually located towards the end of the path instead of near the beginning.
