### PR TITLE
Filter for shouldLoadJavascript() method

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -133,7 +133,7 @@ class Infinite_Scroll {
 		//sanity check
 		if ( !array_key_exists( $options['behavior'], $this->behaviors ) )
 		  return _doing_it_wrong( 'Infinite Scroll behavior', "Behavior {$options['behavior']} not found", $this->version );
-		
+
 		$src = 'behaviors/' . $this->behaviors[ $options['behavior'] ]['src'] . '.js';
 		wp_enqueue_script( $this->slug . "-behavior", plugins_url( $src, __FILE__ ), array( "jquery", $this->slug ), $this->version, true );
 
@@ -304,11 +304,8 @@ class Infinite_Scroll {
 	 */
 	function shouldLoadJavascript() {
 		// Don't need to load the plugin on single pages
-		if (is_singular()) {
-			return false;
-		}
-
-		return true;
+		$load = is_singular() ? false : true;
+		return apply_filters( 'infinite_scroll_load_javascript', $load );
 	}
 }
 


### PR DESCRIPTION
Per my thread at the WP forums: 
http://wordpress.org/support/topic/feature-request-add-filter-for-function-shouldloadjavascript

This would allow me to load Infinite Scroll on a page that is going to list all the users of a certain type (so it is in behaving more like an archive than a single page), but shouldn't effect anyone currently using the plugin.
