### PR TITLE
Fix to make it working with 1.9.0 jQuery

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -797,7 +797,7 @@
 
             if (scrollTimeout) { clearTimeout(scrollTimeout); }
             scrollTimeout = setTimeout(function () {
-                $.event.handle.apply(context, args);
+                $(context).trigger('smartscroll', args);
             }, execAsap === "execAsap" ? 0 : 100);
         }
     };


### PR DESCRIPTION
jQuery at 1.9.0 don't have $.event.handle property so you need to use jQuery's API.
