### PR TITLE
Change 'is_singular()' to 'is_single()' to allow script to load for custom post type archives

### DIFF
--- a/wordpress-plugin/infinite-scroll.php
+++ b/wordpress-plugin/infinite-scroll.php
@@ -304,7 +304,7 @@ class Infinite_Scroll {
 	 */
 	function shouldLoadJavascript() {
 		// Don't need to load the plugin on single pages
-		$load = is_singular() ? false : true;
+		$load = is_single() ? false : true;
 		return apply_filters( 'infinite_scroll_load_javascript', $load );
 	}
 }


### PR DESCRIPTION
Hi-

The big rewrite a couple of revisions ago caused the Wordpress plugin to stop functioning for custom post type archives and in my case at least for a custom query on a custom post type.

This is caused by 'is_singular' being used at the bottom of 'infinite-scroll/infinite-scroll.php' to check for single page views.

Replacing this with 'is_single' restores functionality for custom post type archives and with the custom query I am using. 
