### PR TITLE
'get_media_item_args' filter callback chokes Media modal loading time

### DIFF
--- a/wordpress-plugin/includes/admin.php
+++ b/wordpress-plugin/includes/admin.php
@@ -73,36 +73,35 @@ class Infinite_Scroll_Admin {
 	 */
 	function send_to_editor( $args ) {
 		global $wpdb;
-		
-		if ( $args['errors'] !== null )
-			return $args;
-			
-		if ( isset( $_GET['attachment_id'] ) ) {
-		
-			$id = $_GET['attachment_id'];
-			
-		//workaround for WP 3.2 non-flash upload
-		//not ideal, but works for an edge case
-		} else {
-		
-			//because we can't get the attachment ID at this point, try to pull it from the database
-			//look for the most recent parent-less attachment with same title and mime-type
-			$upload = $GLOBALS['HTTP_POST_FILES']['async-upload'];
-			$title = substr( $upload['name'], 0, strrpos( $upload['name'], '.' ) );
-			$id = $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type = '" . $upload['type'] . "' AND post_parent = '0' AND post_title = '$title' ORDER BY ID DESC LIMIT 1" );
-			
-			//if for some reason we couldn't pull the ID, simply kick
-			//the user will just have to click insert to close the dialog
-			if ( !$id )
+		if (isset($GLOBALS['HTTP_POST_FILES']['async-upload'])){
+			if ( $args['errors'] !== null )
 				return $args;
-		
+				
+			if ( isset( $_GET['attachment_id'] ) ) {
+			
+				$id = $_GET['attachment_id'];
+				
+			//workaround for WP 3.2 non-flash upload
+			//not ideal, but works for an edge case
+			} else {
+			
+				//because we can't get the attachment ID at this point, try to pull it from the database
+				//look for the most recent parent-less attachment with same title and mime-type
+				$upload = $GLOBALS['HTTP_POST_FILES']['async-upload'];
+				$title = substr( $upload['name'], 0, strrpos( $upload['name'], '.' ) );
+				$id = $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type = '" . $upload['type'] . "' AND post_parent = '0' AND post_title = '$title' ORDER BY ID DESC LIMIT 1" );
+				
+				//if for some reason we couldn't pull the ID, simply kick
+				//the user will just have to click insert to close the dialog
+				if ( !$id )
+					return $args;
+			
+			}
+			
+			//rely on WordPress's internal function to output script tags and call send_to_editor()
+			media_send_to_editor( wp_get_attachment_url( $id ) );
 		}
-		
-		//rely on WordPress's internal function to output script tags and call send_to_editor()
-		media_send_to_editor( wp_get_attachment_url( $id ) );
-		
 		return $args;
-		
 	}
 	
 	/**


### PR DESCRIPTION
On large sites with thousands of images, the query run [here](https://github.com/paulirish/infinite-scroll/blob/master/wordpress-plugin/includes/admin.php#L92) can <strong>dramatically</strong> slow down the time it takes for the Media modal to load all of the available images.

The query mentioned above was taking 0.5 to 1.5 seconds to run for <em>each</em> image given that the table columns referenced (post_type, post_mime_type, post_parent and post_title) do <em>not</em> have a multi-column index by default in wp_posts. When query caching is not available it causes severe loading times for the images.

We're assuming the ['send_to_editor' method](https://github.com/paulirish/infinite-scroll/blob/master/wordpress-plugin/includes/admin.php#L74) was meant for the Infinite Scrolling settings page, but it's actually running every time the Media modal is opened - anywhere on the site. Thus, [the logic check](https://github.com/paulirish/infinite-scroll/blob/master/wordpress-plugin/includes/admin.php#L80) is always failing and running the query instead.

Our proposed solution was to only allow the chance of that query running whenever an image has been uploaded. You could add an additional check to see if the user is currently on the Infinite Scrolling settings page, but this worked well enough for us.

Thanks!

---

Majority of credit goes to [Eric Shelkie](https://github.com/shelkie) for meticulously testing the plugin for the exact line of code causing this issue.
