### PR TITLE
Use top offset and height of contentSelector to determine pixelsFromWindowBottomToBottom

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -393,7 +393,8 @@
         _nearbottom: function infscr_nearbottom() {
 
             var opts = this.options,
-            pixelsFromWindowBottomToBottom = 0 + $(document).height() - (opts.binder.scrollTop()) - $(window).height();
+            bottomEdge = $(opts.navSelector).offset().top + $(opts.navSelector).height(),
+            pixelsFromWindowBottomToBottom = 0 + bottomEdge - (opts.binder.scrollTop()) - $(window).height();
 
             // if behavior is defined and this function is extended, call that instead of default
             if (!!opts.behavior && this['_nearbottom_'+opts.behavior] !== undefined) {


### PR DESCRIPTION
> This fixes a bug where two instances of infiniteScroll of different
> heights won't be triggered at their respective navSelector elements
> until you get to the bottom of the window.

Use case:
1. Have a sidebar and content with different subset of posts
2. Each column needs to independently scroll
3. Before patch, the next pages would be reloaded only when I reach the window bottom, even if one of the columns was 500px shorter
4. Now each column will reload independently when it's navSelector is reached

Tests aren't affected and my own use case now works flawlessly.
