### PR TITLE
Delay before loading data

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ $('.selector').infinitescroll({
 		msg: null,
 		msgText: "<em>Loading the next set of posts...</em>",
 		selector: null,
+		delay: 0, // Delay before loading data (milliseconds)
 		speed: 'fast',
 		start: undefined
 	},

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -33,6 +33,7 @@
             msg: null,
             msgText: "<em>Loading the next set of posts...</em>",
             selector: null,
+            delay: 0, // Delay before loading data (milliseconds)
             speed: 'fast',
             start: undefined
         },
@@ -153,8 +154,11 @@
                 opts.loading.msg
                 .appendTo(opts.loading.selector)
                 .show(opts.loading.speed, $.proxy(function() {
-					this.beginAjax(opts);
-				}, self));
+                    var that = this;
+                    setTimeout(function() {
+                        that.beginAjax(opts);
+                    }, opts.loading.delay);
+                }, self));
             };
 
             // determine loading.finished actions


### PR DESCRIPTION
Hello.

In our current project we have got a request from client: to set a pause before starting data loading. Because, with fast internet, a data appears very quickly and sometimes user can't understand what happened.

I just add a new parameter `delay`, which equals 0 if it isn't set.

Maybe it isn't the best solution, but I tried to share our use case. It can be useful not only our client.

Thank you for your job!
