### PR TITLE
Fixed prefill issue where content wasn't loading, even though document was larger than screen.

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -200,11 +200,11 @@
 
 		_prefill: function infscr_prefill() {
 			var instance = this;
-			var $document = $(document);
+			var $contentSelector = $(this.options.contentSelector);
 			var $window = $(window);
 
 			function needsPrefill() {
-				return ($document.height() <= $window.height());
+				return ($contentSelector.height() <= $window.height());
 			}
 
 			this._prefill = function() {


### PR DESCRIPTION
On my app, I have a page where the left-nav makes the document larger than the window.  However, the content pane in the right side is blank.

The needsPrefill function checks whether the document is smaller than the window; if it is, the code gets elements until the document is larger.  However, in my case, the document is already larger than the window.  The result is that I have a blank content div.

My change is to modify needsPrefill to use the content div's size, instead of the whole document size.
