### PR TITLE
allow callbacks to trigger the finishedMsg and end

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,3 +89,6 @@ $('.selector').infinitescroll({
   // Do something with JSON data, create DOM elements, etc ..
 });
 ```
+
+The callback can return the string "end" to indicate the end of the data.
+Infinite Scroll will flash the finishedMsg and unbind itself from the element.

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -172,7 +172,9 @@
                 }
 
                 if (callback) {
-                    callback.call($(opts.contentSelector)[0], data, opts, url);
+                    if(callback.call($(opts.contentSelector)[0], data, opts, url) == 'end') {
+                        self._error('end')
+                    }
                 }
 
 				if (opts.prefill) {
@@ -386,7 +388,9 @@
 				opts.state.isDuringAjax = false;
 			}
 
-            callback(this, data, url);
+            if(callback(this, data, url) == 'end') {
+                this._error('end');
+            }
 
 			if (opts.prefill) {
 				this._prefill();


### PR DESCRIPTION
Callbacks are super handy but they don't have the ability to end the infinity.  That's a difficult limitation.

This shows how I implemented it in my app.  It's maybe not so pretty but it works great!  If you have a better idea on how to do it I'm happy to rework the patch.
