### PR TITLE
add option to send ajax data straight to the callback

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -342,7 +342,7 @@
 					return false;
 
 				case 'no-append':
-					if (opts.dataType === 'html') {
+					if (opts.dataType === 'html' && !opts.dontScrewUpTheData) {
 						data = '<div>' + data + '</div>';
 						data = $(data).find(opts.itemSelector);
 					}


### PR DESCRIPTION
I have a callback that receives html data, then inserts it in the correct place in the DOM.  Unfortunately, Infinite Scroll corrupts the data before the callback can be called.

This option prevents that.

This is likely too dirty to be merged but, with some feedback from someone who understands how things are supposed to work, I hope it can be turned into a proper fix.

Here's the way I use it:

``` javascript
  //
  //        infinite scroll
  //
  $("#assets").infinitescroll(
    {
      loading: {
        msgText: "Loading more listings...",
        finishedMsg: "No more listings."
      },
      navSelector:  "nav.pagination",
      nextSelector: "nav.pagination a[rel=next]",
      appendCallback: false,
      dontScrewUpTheData: true,
      path: function (page) {
        var query = window.location.search.replace(/([?;&])page=[0-9]+[?;&]/, "$1")  // remove ?page= from querystring
        return "/results" + (query.length > 2 ? query + "&" : "?") + "page=" + page
      },
    },
    function (data,opts,url) {
      if(data.trim() != "") {
        compute_destination().append(data)
      } else {
        return "end"
      }
    }
  )
  // unfortunately infinitescroll doesn't hide the paginators until AFTER it starts
  // ajaxing the new content so the paginators appear & flash off quickly.  Ugly.
  // Quick workaround that won't get in the way if javascript is turned off:
  $('nav.pagination').hide()
```

I'm very open to comments on how I can do this better.  Just muddling along the best I can...
