### PR TITLE
Destroy method improved to clear jquery data on the container

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -514,7 +514,8 @@
         // Destroy current instance of plugin
         destroy: function infscr_destroy() {
             this.options.state.isDestroyed = true;
-			this.options.loading.finished();
+            this.options.loading.finished();
+            this.element.data('infinitescroll', null);
             return this._error('destroy');
         },
 


### PR DESCRIPTION
After infinitescroll calls destroy method on element it cannot be reinited on same element because jquery data still stored on it and prevents it from secondary initialization with this change infinitescroll jquery data also removed upon destroying.
