### PR TITLE
add functionality to use POST requests in ajax json request as well as G...

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -63,9 +63,9 @@
         pixelsFromNavToBottom: undefined,
         path: undefined, // Either parts of a URL as an array (e.g. ["/page/", "/"] or a function that takes in the page number and returns a URL
 		prefill: false, // When the document is smaller than the window, load data until the document is larger or links are exhausted
-        maxPage: undefined // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+        maxPage: undefined, // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
         type: 'GET', // to switch between GET/POST requests with ajax calls
-        data: undefined, // the POST data if we are using POST instead of GET
+        data: undefined // the POST data if we are using POST instead of GET
 	};
 
     $.infinitescroll.prototype = {

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -64,6 +64,8 @@
         path: undefined, // Either parts of a URL as an array (e.g. ["/page/", "/"] or a function that takes in the page number and returns a URL
 		prefill: false, // When the document is smaller than the window, load data until the document is larger or links are exhausted
         maxPage: undefined // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+        type: 'GET', // to switch between GET/POST requests with ajax calls
+        data: undefined, // the POST data if we are using POST instead of GET
 	};
 
     $.infinitescroll.prototype = {
@@ -584,7 +586,8 @@
 					instance._debug('Using ' + (method.toUpperCase()) + ' via $.ajax() method');
 					$.ajax({
 						dataType: 'json',
-						type: 'GET',
+						type: opts.type,
+                        data: opts.posts,
 						url: desturl,
 						success: function (data, textStatus, jqXHR) {
 							condition = (typeof (jqXHR.isResolved) !== 'undefined') ? (jqXHR.isResolved()) : (textStatus === "success" || textStatus === "notmodified");


### PR DESCRIPTION
I wanted to send my data as a POST request instead of a GET request in my AJAX call to stop me having to modify my filter functionality. To do this, all I had to do was change the 'type' field for the 'json' method to be a value that could be passed in, and to add my new field 'data' which I used to pass in my form posts. I added "type:'get'" and "data:undefined" as my default values for this. (not sure if I should have updated minified version as well, I'm new to contributing to open source!).
