### PR TITLE
Add responseText and pluginInstance to callback options array.

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -330,6 +330,11 @@
             result = (opts.state.isDone) ? 'done' : (!opts.appendCallback) ? 'no-append' : 'append',
             frag;
 
+            // Let the callbacks have access to the original responseText and the plugin instance. This can be used to preemptively finish
+            // infinite scroll for working, by checking if next links are available in the response text.
+            opts.responseText = data;
+            opts.pluginInstance = this;
+
             // if behavior is defined and this function is extended, call that instead of default
             if (!!opts.behavior && this['_loadcallback_'+opts.behavior] !== undefined) {
                 this['_loadcallback_'+opts.behavior].call(this,box,data);


### PR DESCRIPTION
I've added additional parameters to the opts array, to let callbacks have access to the original Ajax response text, and the plugin instance.

Specifically this can be useful when you want to try and find "pager next" links in the response Text, and if there is no next link, tell the plugin instance that there are no more pages available, and that the current new page is the last one. This will stop the plugin from creating one more Load More button, when we already know no more new pages are available.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/paulirish/infinite-scroll/538)

<!-- Reviewable:end -->
