### PR TITLE
Return error if ! appendCallback

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -354,6 +354,12 @@
                         data = '<div>' + data + '</div>';
                         data = $(data).find(opts.itemSelector);
                     }
+
+                    // if it didn't return anything
+                    if (data.length === 0) {
+                        return this._error('end');
+                    }
+
                     break;
 
                 case 'append':


### PR DESCRIPTION
if the `appendCallback` parameter is explicitly set to `false`, and we hit the `'no-append'` case, then we should also `return this._error('end');` if there are no items to append.
