### PR TITLE
Add xhrCallback callback func to opts and call it on success request

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -67,6 +67,7 @@
         appendCallback: true,
         bufferPx: 40,
         errorCallback: function () { },
+        xhrCallback: function () { },
         infid: 0, //Instance ID
         pixelsFromNavToBottom: undefined,
         path: undefined, // Either parts of a URL as an array (e.g. ["/page/", "/"] or a function that takes in the page number and returns a URL
@@ -565,8 +566,9 @@
             switch (method) {
                 case 'html+callback':
                     instance._debug('Using HTML via .load() method');
-                    box.load(desturl + ' ' + opts.itemSelector, undefined, function infscr_ajax_callback(responseText) {
+                    box.load(desturl + ' ' + opts.itemSelector, undefined, function infscr_ajax_callback(responseText, textStatus, jqXHR) {
                         instance._loadcallback(box, responseText, desturl);
+                        opts.xhrCallback(jqXHR);
                     });
 
                     break;
@@ -581,6 +583,7 @@
                             condition = (typeof (jqXHR.isResolved) !== 'undefined') ? (jqXHR.isResolved()) : (textStatus === "success" || textStatus === "notmodified");
                             if (condition) {
                                 instance._loadcallback(box, jqXHR.responseText, desturl);
+                                opts.xhrCallback(jqXHR);
                             } else {
                                 instance._error('end');
                             }
@@ -604,6 +607,7 @@
                                     box.append(theData);
                                     if (condition) {
                                         instance._loadcallback(box, theData);
+                                        opts.xhrCallback(jqXHR);
                                     } else {
                                         instance._error('end');
                                     }
@@ -615,6 +619,7 @@
                                 // if appendCallback is false, we will pass in the JSON object. you should handle it yourself in your callback.
                                 if (condition) {
                                     instance._loadcallback(box, data, desturl);
+                                    opts.xhrCallback(jqXHR);
                                 } else {
                                     instance._error('end');
                                 }


### PR DESCRIPTION
You may need to do some extra stuff with result XMLHttpRequest
when it's done. So here is a callback function that will be called
everytime when new page's request has finished successfully.

In my case I need this to get some data (pagination cursor for next
page) from extra HTTP header each time when a content loaded from a
destination resource.
