### PR TITLE
infscr_loadcallback behavior call function missing url parameter

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -340,7 +340,7 @@
 
             // if behavior is defined and this function is extended, call that instead of default
             if (!!opts.behavior && this['_loadcallback_'+opts.behavior] !== undefined) {
-                this['_loadcallback_'+opts.behavior].call(this,box,data);
+                this['_loadcallback_'+opts.behavior].call(this,box,data,url);
                 return;
             }
 


### PR DESCRIPTION
When using a custom infscr_loadcallback behavior, the url isn't available in the parameters.

Apart from this, I would like to continue after the custom callback function. So is this possible?

```
if (!!opts.behavior && this['_loadcallback_'+opts.behavior] !== undefined) {
    return this['_loadcallback_'+opts.behavior].call(this,box,data,url);
}
```
