### PR TITLE
Pass in 'opts' when call opts.loading.finished() in destroy()

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -528,7 +528,7 @@
         // Destroy current instance of plugin
         destroy: function infscr_destroy() {
             this.options.state.isDestroyed = true;
-            this.options.loading.finished();
+            this.options.loading.finished(this.options);
             return this._error('destroy');
         },
 


### PR DESCRIPTION
This would make it easier for user who uses custom the opts.loading.finished to access 'opts' props (like opts.state).

On the other hand, I found the other places -- where opts.loading.finished() is called -- already pass in 'opts' as the first argument. So, this code change would still make the argument list consistent to existing one.
