### PR TITLE
fix infscr_showdonemsg when no image was used

### DIFF
--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -492,8 +492,9 @@
 
             opts.loading.msg
             .find('img')
-            .hide()
-            .parent()
+            .hide();
+            
+            opts.loading.msg
             .find('div').html(opts.loading.finishedMsg).animate({ opacity: 1 }, 2000, function () {
                 $(this).parent().fadeOut(opts.loading.speed);
             });


### PR DESCRIPTION
Fixes hiding of message at the end of the list in case a custom `msg` was used that does not contain an `img`.
