### PR TITLE
Fixed inline script code removal and script execution.

### DIFF
--- a/dist/infinite-scroll.pkgd.js
+++ b/dist/infinite-scroll.pkgd.js
@@ -1073,12 +1073,16 @@ function getItemsFragment( items ) {
 // <script>s added by InfiniteScroll will not load
 // similar to https://stackoverflow.com/questions/610995
 function refreshScripts( fragment ) {
-  var scripts = fragment.querySelectorAll('script');
   for ( var i=0; i < scripts.length; i++ ) {
-    var script = scripts[i];
-    var freshScript = document.createElement('script');
-    copyAttributes( script, freshScript );
-    script.parentNode.replaceChild( freshScript, script );
+    if(scripts[i]['innerHTML'].length) {
+      eval(scripts[i]['innerHTML']);
+    }
+    else {
+      var script = scripts[i];
+      var freshScript = document.createElement('script');
+      copyAttributes( script, freshScript );
+      script.parentNode.replaceChild( freshScript, script );
+    }
   }
 }
 


### PR DESCRIPTION
@desandro @metafizzy. Please review and merge the code. Because this function removes code between script tags when loading next page.

Also If I commented code of this function script tag code are there but not working. So I have made my changes to work it.

Please let me know if you have any suggestions.