### PR TITLE
Replace negative lookbehind with a more supported regular expression

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -235,7 +235,7 @@ proto.updateGetPathTemplate = function( optPath ) {
   // convert path option into regex to look for pattern in location
   // escape query (?) in url, allows for parsing GET parameters 
   var regexString = optPath
-    .replace(/(\\\?|\?)/, '\\?')
+    .replace( /(\\\?|\?)/, '\\?' )
     .replace( '{{#}}', '(\\d\\d?\\d?)' );
   var templateRe = new RegExp( regexString );
   var match = location.href.match( templateRe );

--- a/js/core.js
+++ b/js/core.js
@@ -235,7 +235,7 @@ proto.updateGetPathTemplate = function( optPath ) {
   // convert path option into regex to look for pattern in location
   // escape query (?) in url, allows for parsing GET parameters 
   var regexString = optPath
-    .replace(/(?<!\\)\?/, '\\?')
+    .replace(/(\\\?|\?)/, '\\?')
     .replace( '{{#}}', '(\\d\\d?\\d?)' );
   var templateRe = new RegExp( regexString );
   var match = location.href.match( templateRe );

--- a/js/core.js
+++ b/js/core.js
@@ -233,9 +233,13 @@ proto.updateGetPathTemplate = function( optPath ) {
   }.bind( this );
   // get pageIndex from location
   // convert path option into regex to look for pattern in location
-  var regexString = optPath.replace( '{{#}}', '(\\d\\d?\\d?)' );
+  // escape query (?) in url, allows for parsing GET parameters 
+  var regexString = optPath
+    .replace('?', '\\?')
+    .replace( '{{#}}', '(\\d\\d?\\d?)' );
   var templateRe = new RegExp( regexString );
   var match = location.href.match( templateRe );
+
   if ( match ) {
     this.pageIndex = parseInt( match[1], 10 );
     this.log( 'pageIndex', [ this.pageIndex, 'template string' ] );

--- a/js/core.js
+++ b/js/core.js
@@ -235,7 +235,7 @@ proto.updateGetPathTemplate = function( optPath ) {
   // convert path option into regex to look for pattern in location
   // escape query (?) in url, allows for parsing GET parameters 
   var regexString = optPath
-    .replace('?', '\\?')
+    .replace(/(?<!\\)\?/, '\\?')
     .replace( '{{#}}', '(\\d\\d?\\d?)' );
   var templateRe = new RegExp( regexString );
   var match = location.href.match( templateRe );

--- a/test/unit/page-index.js
+++ b/test/unit/page-index.js
@@ -38,4 +38,17 @@ QUnit.test( 'pageIndex', function( assert ) {
   assert.equal( infScroll.pageIndex, 8, 'pageIndex from GET param with {{#}}' );
 
   history.replaceState( null, document.title, prevURL );
+
+  infScroll.destroy();
+
+  history.replaceState(null, document.title, 'page?currPage=8');
+  infScroll = new InfiniteScroll( demoElem, {
+    path: 'page\\?currPage={{#}}',
+    history: false,
+    scrollThreshold: false,
+  });
+
+  assert.equal( infScroll.pageIndex, 8, 'pageIndex from GET param with {{#}} and pre-escaped regexp' );
+
+  history.replaceState( null, document.title, prevURL );
 });

--- a/test/unit/page-index.js
+++ b/test/unit/page-index.js
@@ -26,4 +26,16 @@ QUnit.test( 'pageIndex', function( assert ) {
 
   history.replaceState( null, document.title, prevURL );
 
+  infScroll.destroy();
+
+  history.replaceState(null, document.title, 'page?currPage=8');
+  infScroll = new InfiniteScroll( demoElem, {
+    path: 'page?currPage={{#}}',
+    history: false,
+    scrollThreshold: false,
+  });
+
+  assert.equal( infScroll.pageIndex, 8, 'pageIndex from GET param with {{#}}' );
+
+  history.replaceState( null, document.title, prevURL );
 });


### PR DESCRIPTION
The change introduced in #832 used a regular expression not supported in all browser.  This regular expression has been removed and replaced with a functional equivalent.  

The replacement regex looks for an unescaped or already escaped question mark and replaces it with an escaped one.  While it isn't as pretty since we still replace a properly escaped query, it was the most straightforward solution that didn't require additional conditional logic.