### PR TITLE
Allow retry when error And let error event get more info

### DIFF
--- a/js/page-load.js
+++ b/js/page-load.js
@@ -44,13 +44,13 @@ InfiniteScroll.create.pageLoad = function() {
 };
 
 proto.onScrollThresholdLoad = function() {
-  if ( this.options.loadOnScroll ) {
+  if ( this.options.loadOnScroll && this.canLoad ) {
     this.loadNextPage();
   }
 };
 
 proto.loadNextPage = function() {
-  if ( this.isLoading || !this.canLoad ) {
+  if ( this.isLoading ) {
     return;
   }
 
@@ -78,6 +78,7 @@ proto.onPageLoad = function( response, path ) {
   if ( !this.options.append ) {
     this.isLoading = false;
   }
+  this.canLoad = true;
   this.pageIndex++;
   this.loadCount++;
   this.dispatchEvent( 'load', null, [ response, path ] );

--- a/js/page-load.js
+++ b/js/page-load.js
@@ -284,7 +284,7 @@ function request( url, responseType, onLoad, onError, onLast ) {
       onLast( req.response );
     } else {
       // not 200 OK, error
-      var error = new Error( req.statusText );
+      var error = new Error( req.response );
       onError( error );
     }
   };


### PR DESCRIPTION
When error, the "infinite-scroll-error" element could show "Error, <a onlick="infScroll.loadNextPage()>Click here Retry</a>", give a chance to user for retry, if success, Reset `canLoad` to true, everything go on.