### PR TITLE
add pathRegexes

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -227,6 +227,8 @@ let pathRegexes = [
   /^(.*?\/?page\/?)(\d\d?\d?)(.*?$)/,
   // Drupal - example.com/?page=1
   /^(.*?\/?\?page=)(\d\d?\d?)(.*?$)/,
+  // Rails - example.com/?name=test&page=1
+  /^(.*?\/?\&page=)(\d\d?\d?)(.*?$)/,
   // catch all, last occurence of a number
   /(.*?)(\d\d?\d?)(?!.*\d)(.*?$)/,
 ];

--- a/js/core.js
+++ b/js/core.js
@@ -227,7 +227,7 @@ let pathRegexes = [
   /^(.*?\/?page\/?)(\d\d?\d?)(.*?$)/,
   // Drupal - example.com/?page=1
   /^(.*?\/?\?page=)(\d\d?\d?)(.*?$)/,
-  // Rails - example.com/?name=test&page=1
+  // Rails - example.com/?name=test&page=1&body=test
   /^(.*?\/?\&page=)(\d\d?\d?)(.*?$)/,
   // catch all, last occurence of a number
   /(.*?)(\d\d?\d?)(?!.*\d)(.*?$)/,


### PR DESCRIPTION

# issue
If you have a path such as `example.com/?name=test&page=1&post_id=1`, the previous pathRegexes will not work properly.

